### PR TITLE
Explicitly set default content type header. 

### DIFF
--- a/lib/logglier/client/http/sync.rb
+++ b/lib/logglier/client/http/sync.rb
@@ -35,6 +35,8 @@ module Logglier
           @headers = {}
           if @format == :json
             @headers['Content-Type'] = 'application/json'
+          else
+            @headers['Content-Type'] = 'text/plain'
           end
 
           connect!

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -23,6 +23,11 @@ describe 'HTTP' do
     proxy.failsafe.should == $stderr
   end
 
+  it "defaults Content-Type header to text/plain" do
+    @http.should_receive(:request_post).with(anything(), anything(), hash_including('Content-Type' => 'text/plain'))
+    @proxy.deliver('message')
+  end
+
   describe "error handling" do
     Logglier::Client::HTTP::NetHTTPProxy::RETRY_EXCEPTIONS.each do |error|
       context "for #{error}" do


### PR DESCRIPTION
Recently, Loggly seems to changed it's Input API behavior.

POST to Loggly Input API without Content-Type header.

```
$ curl -X POST \
  -d "HTTP POST without Content-Type header" \
  https://logs.loggly.com/inputs/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
$ curl -u user:password "https://subdomain.loggly.com/api/search?q=without"
{
    "data": [
        {
            "timestamp": "2011-11-08T09:59:56.999Z",
            "isjson": false,
            "ip": "10.0.0.1",
            "inputname": "default",
            "inputid": "5457",
            "text": "{\"HTTP POST without Content-Type header\":\"\"}"
        }
    ],
    ...
}
```

`data[0].text` is stored as a JSON string.

Same with Content-Type: text/plain header.

```
$ curl -X POST \
  -H "Content-Type: text/plain" \
  -d "HTTP POST with Content-Type: text/plain header" \
  https://logs.loggly.com/inputs/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
$ curl -i -u user:password "https://subdomain.loggly.com/api/search?q=plain"
{
    "data": [
        {
            "timestamp": "2011-11-08T10:06:49.472Z",
            "isjson": false,
            "ip": "10.0.0.1",
            "inputname": "default",
            "inputid": "5457",
            "text": "HTTP POST with Content-Type header"
        }
    ],
    ...
}
```

`data[0].text` is stored as a plain text.
