### PR TITLE
Fix for threaded delivery under Unicorn

### DIFF
--- a/lib/logglier/client/http.rb
+++ b/lib/logglier/client/http.rb
@@ -14,7 +14,7 @@ module Logglier
         setup_input_uri(opts)
         @format = opts[:format] ? opts[:format].to_sym : nil
         @deliverer = if opts[:threaded]
-          Logglier::Client::HTTP::DeliveryThread.new(@input_uri, opts)
+          Logglier::Client::HTTP::DeliveryThreadManager.new(@input_uri, opts)
         else
           Logglier::Client::HTTP::NetHTTPProxy.new(@input_uri, opts)
         end

--- a/spec/threaded_spec.rb
+++ b/spec/threaded_spec.rb
@@ -19,3 +19,43 @@ describe Logglier::Client::HTTP::DeliveryThread do
     subject.join
   end
 end
+
+describe Logglier::Client::HTTP::DeliveryThreadManager do
+  before do
+    @mock_http = MockNetHTTPProxy.new
+    Logglier::Client::HTTP::NetHTTPProxy.stub(:new) { @mock_http }
+  end
+
+  subject { described_class.new(URI.parse('http://localhost')) }
+
+  it "should instantiate a delivery_thread" do
+    Logglier::Client::HTTP::DeliveryThread.should_receive(:new).once
+    subject
+  end
+
+  it "should deliver messages via delivery_thread" do
+    @mock_thread = Object.new
+    @mock_thread.stub(:alive?) { true }
+    @mock_thread.should_receive(:deliver).once.with('foo')
+    Logglier::Client::HTTP::DeliveryThread.should_receive(:new).once.and_return(@mock_thread)
+
+    subject.deliver('foo')
+  end
+
+  it "should respawn a dead delivery_thread" do
+    @first_thread = subject.instance_variable_get(:@thread)
+    @first_thread.should_receive(:deliver).once.with('first')
+
+    subject.deliver('first')
+
+    @first_thread.kill
+
+    subject.deliver('force respawn')
+
+    @second_thread = subject.instance_variable_get(:@thread)
+    @second_thread.should_not eql(@first_thread)
+    @second_thread.should_receive(:deliver).once.with('second')
+
+    subject.deliver('second')
+  end
+end


### PR DESCRIPTION
This is necessary for preforking servers such as Unicorn, since forking
causes the thread to be killed.  This case can be reproduced by initializing
a logglier instance in a Rails config and running the app under Unicorn with
`preload_app true`.  In that case, the thread would be killed, and the @queue
would become a blackhole where messages silently disappear.
