### PR TITLE
Add JSON support to syslog client, add PID to progname

### DIFF
--- a/lib/logglier/client.rb
+++ b/lib/logglier/client.rb
@@ -74,7 +74,14 @@ module Logglier
 
       def massage_message(incoming_message, severity, processid)
         outgoing_message = ""
-        outgoing_message << "pid=#{processid}, severity=#{severity}, "
+
+        # Append PID and severity to message, unless we're a Syslog
+        # client. If we're a Syslog client, that information is already
+        # in the Syslog packet.
+        unless self.is_a?(Logglier::Client::Syslog)
+          outgoing_message << "pid=#{processid}, severity=#{severity}, "
+        end
+
         case incoming_message
         when Hash
           outgoing_message << masher(incoming_message)

--- a/lib/logglier/client/syslog.rb
+++ b/lib/logglier/client/syslog.rb
@@ -9,7 +9,7 @@ module Logglier
     class Syslog
       include Logglier::Client::InstanceMethods
 
-      attr_reader :input_uri, :facility, :syslog
+      attr_reader :input_uri, :facility, :format, :syslog
 
       def initialize(opts={})
         setup_input_uri(opts)
@@ -35,6 +35,7 @@ module Logglier
           @facility = 16
         end
 
+        @format = opts[:format]
         @hostname = opts[:hostname] || Socket.gethostname.split('.').first
       end
 
@@ -88,7 +89,14 @@ module Logglier
           else
             message << "#{$0}[#{processid}]: "
           end
-          message << massage_message(msg,severity,processid)
+
+          # Support logging JSON to Syslog
+          if @format == :json && msg.is_a?(Hash)
+            message << MultiJson.dump(msg)
+          else
+            message << massage_message(msg,severity,processid)
+          end
+
           if @input_uri.scheme == 'tcp'
             message << "\r\n"
           end

--- a/lib/logglier/client/syslog.rb
+++ b/lib/logglier/client/syslog.rb
@@ -81,6 +81,8 @@ module Logglier
         proc do |severity, datetime, progname, msg|
           processid=Process.pid
           message = "<#{pri(severity)}>#{datetime.strftime(datetime_format)} #{@hostname} "
+
+          # Include process ID in progname/log tag - RFC3164 § 5.3
           if progname
             message << "#{progname}[#{processid}]: "
           else

--- a/lib/logglier/client/syslog.rb
+++ b/lib/logglier/client/syslog.rb
@@ -82,9 +82,9 @@ module Logglier
           processid=Process.pid
           message = "<#{pri(severity)}>#{datetime.strftime(datetime_format)} #{@hostname} "
           if progname
-            message << "#{progname}: "
+            message << "#{progname}[#{processid}]: "
           else
-            message << "#{$0}: "
+            message << "#{$0}[#{processid}]: "
           end
           message << massage_message(msg,severity,processid)
           if @input_uri.scheme == 'tcp'

--- a/spec/client/syslog_spec.rb
+++ b/spec/client/syslog_spec.rb
@@ -35,7 +35,7 @@ describe Logglier::Client::Syslog do
 
       it 'formats as a massaged message when the format is not JSON' do
         message = client.formatter.call 'INFO', Time.now, 'banana', testing_json: false
-        message.should match(/, testing_json=false\z/)
+        message.should match(/: testing_json=false\z/)
       end
     end
   end

--- a/spec/client/syslog_spec.rb
+++ b/spec/client/syslog_spec.rb
@@ -11,4 +11,32 @@ describe Logglier::Client::Syslog do
       client.pri("WARN").should == (17 << 3) + 4
     end
   end
+
+  describe '#formatter' do
+    before do
+      UDPSocket.stub(:new).and_return(mock('socket').as_null_object)
+      TCPSocket.stub(:new).and_return(mock('Socket').as_null_object)
+    end
+
+    let(:client)      { described_class.new(input_url: 'udp://127.0.0.1:514/17') }
+    let(:json_client) { described_class.new(input_url: 'udp://127.0.0.1:514/17', format: :json) }
+
+    it 'includes the PID in the progname' do
+      message = client.formatter.call 'INFO', Time.now, 'banana', 'test message'
+
+      message.should match(/banana\[#{Process.pid}\]: /)
+    end
+
+    context 'when you pass a Hash' do
+      it 'formats as JSON when the format is JSON' do
+        message = json_client.formatter.call 'INFO', Time.now, 'banana', testing_json: true
+        message.should match(/: {"testing_json":true}\z/)
+      end
+
+      it 'formats as a massaged message when the format is not JSON' do
+        message = client.formatter.call 'INFO', Time.now, 'banana', testing_json: false
+        message.should match(/, testing_json=false\z/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The PID should be in the progname according to the RFC. This PR adds it there. It also stops duplicating the severity and PID on syslog messages - they're included in the syslog header, no need to repeat them.

This PR also adds JSON support to the syslog client. Loggly can read the JSON log entries and handles them the same as it does over HTTP.