### PR TITLE
Up Ruby Version Requirement

### DIFF
--- a/logglier.gemspec
+++ b/logglier.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'logglier'
 
-  s.required_ruby_version     = '>= 1.8.6'
+  s.required_ruby_version     = '>= 2.1.8'
   s.required_rubygems_version = '>= 1.3.6'
 
   s.add_runtime_dependency 'multi_json', '~> 1'


### PR DESCRIPTION
I noticed that the `.travis.yml` file only tests Ruby versions 2.1.8,
2.2.4 and 2.3.0.

Ruby 2.3.0 is scheduled to be EOL status March of 2019 and 2.2 and 2.1
are already marked as EOL. I would suggest updating to at least 2.3 if
not newer in a new gem version.

More about Ruby version maintenance here: https://www.ruby-lang.org/en/downloads/branches/

